### PR TITLE
docs: remove link to task tracker issue from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,8 +14,9 @@ What kind of change does this PR introduce?
 
 #### Related Tasks
 
-List any related task links from the issue tracker:  
-[EA-5](https://deadliners.atlassian.net/browse/EA-5?atlOrigin=eyJpIjoiNTc4OGJiZWJkMmM3NDgxMTgxNWJkNzdhMTg3NDc2YTQiLCJwIjoiaiJ9)
+List any related task links from the issue tracker:
+
+- **EA-5**: Create a pull request template with a clear structure for describing proposed changes and the rationale behind them
 
 #### Changes made
 


### PR DESCRIPTION
#### PR Type

What kind of change does this PR introduce?

- [ ] New feature
- [ ] Breaking change
- [ ] Bug fix
- [x] Docs
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Tests
- [ ] Other

#### Related Tasks

[EA-72](https://deadliners.atlassian.net/jira/software/projects/EA/boards/2?selectedIssue=EA-72)

#### Changes made

- [x] Link to task tracker substituted with list item with task id and task title

#### Additional info

Based on mentor's check
