### PR TITLE
Fix/EA-113/fix registration form

### DIFF
--- a/__tests__/header.test.tsx
+++ b/__tests__/header.test.tsx
@@ -43,4 +43,4 @@ describe('MainHeader Component', () => {
       });
     });
   });
-}); // Add this line
+});

--- a/__tests__/login-form/login-form.test.tsx
+++ b/__tests__/login-form/login-form.test.tsx
@@ -1,9 +1,13 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import { useRouter } from 'next/navigation';
 import mockMatchMedia from '../../utils/mock';
 import LoginForm from '../../components/login-form/login-form';
-import { Placeholders, ValidationMessages } from '../../components/login-form/types.login';
-import { useRouter } from 'next/navigation';
+import {
+  Placeholders,
+  EmailValidationMessages,
+  PasswordValidationMessages,
+} from '../../components/login-form/types.login';
 
 jest.mock('next/navigation');
 
@@ -37,8 +41,8 @@ describe('LoginForm - basic tests', () => {
 
     fireEvent.click(screen.getByText('Sign in'));
 
-    expect(await screen.findByText(ValidationMessages.EmailRequired)).toBeInTheDocument();
-    expect(await screen.findByText(ValidationMessages.PasswordRequired)).toBeInTheDocument();
+    expect(await screen.findByText(EmailValidationMessages.required)).toBeInTheDocument();
+    expect(await screen.findByText(PasswordValidationMessages.required)).toBeInTheDocument();
   });
 });
 
@@ -49,13 +53,13 @@ describe('LoginForm - email validation', () => {
     fireEvent.change(screen.getByPlaceholderText(Placeholders.Email), { target: { value: 'testtest.com' } });
 
     await waitFor(() => {
-      expect(screen.getByText(ValidationMessages.EmailInvalid)).toBeInTheDocument();
+      expect(screen.getByText(EmailValidationMessages.invalid)).toBeInTheDocument();
     });
 
     fireEvent.change(screen.getByPlaceholderText(Placeholders.Email), { target: { value: 'test@test.com' } });
 
     await waitFor(() => {
-      expect(screen.queryByText(ValidationMessages.EmailInvalid)).not.toBeInTheDocument();
+      expect(screen.queryByText(EmailValidationMessages.invalid)).not.toBeInTheDocument();
     });
   });
 
@@ -70,7 +74,7 @@ describe('LoginForm - email validation', () => {
 
     fireEvent.change(screen.getByPlaceholderText(Placeholders.Email), { target: { value: email } });
 
-    expect(await screen.findByText(ValidationMessages.EmailInvalid)).toBeInTheDocument();
+    expect(await screen.findByText(EmailValidationMessages.invalid)).toBeInTheDocument();
   });
 });
 
@@ -81,29 +85,45 @@ describe('LoginForm - password validation', () => {
     fireEvent.change(screen.getByPlaceholderText(Placeholders.Password), { target: { value: '12345sS' } });
 
     await waitFor(() => {
-      expect(screen.getByText(formatMessage(ValidationMessages.PasswordPattern))).toBeInTheDocument();
+      expect(screen.getByText(formatMessage(PasswordValidationMessages.isShort))).toBeInTheDocument();
     });
 
     fireEvent.change(screen.getByPlaceholderText(Placeholders.Password), { target: { value: '12345sS!' } });
 
     await waitFor(() => {
-      expect(screen.queryByText(formatMessage(ValidationMessages.PasswordPattern))).not.toBeInTheDocument();
+      expect(screen.queryByText(formatMessage(PasswordValidationMessages.isShort))).not.toBeInTheDocument();
     });
   });
 
   test.each([
-    [`${TestMessage.InvalidPassword} if less than 8 characters were used`, '1234sS!'],
-    [`${TestMessage.InvalidPassword} with leading whitespace`, ' sS1!sS1!'],
-    [`${TestMessage.InvalidPassword} with trailing whitespace`, 'sS1!sS1! '],
-    [`${TestMessage.InvalidPassword} without lowercase character`, 'SS1!SS1!S'],
-    [`${TestMessage.InvalidPassword} without uppercase character`, 'ss1!ss1!s'],
-    [`${TestMessage.InvalidPassword} without digit character`, 'ssS!ssS!s'],
-    [`${TestMessage.InvalidPassword} without special character`, 'ssSsssS1s'],
-  ])('%s - "%s"', async (_, password) => {
+    [
+      `${TestMessage.InvalidPassword} if less than 8 characters were used`,
+      '1234sS!',
+      PasswordValidationMessages.isShort,
+    ],
+    [`${TestMessage.InvalidPassword} with leading whitespace`, ' sS1!sS1!', PasswordValidationMessages.hasWhitespaces],
+    [`${TestMessage.InvalidPassword} with trailing whitespace`, 'sS1!sS1! ', PasswordValidationMessages.hasWhitespaces],
+    [
+      `${TestMessage.InvalidPassword} without lowercase character`,
+      'SS1!SS1!S',
+      PasswordValidationMessages.hasNoLowercase,
+    ],
+    [
+      `${TestMessage.InvalidPassword} without uppercase character`,
+      'ss1!ss1!s',
+      PasswordValidationMessages.hasNoUppercase,
+    ],
+    [`${TestMessage.InvalidPassword} without digit character`, 'ssS!ssS!s', PasswordValidationMessages.hasNoNumber],
+    [
+      `${TestMessage.InvalidPassword} without special character`,
+      'ssSsssS1s',
+      PasswordValidationMessages.hasNoSpecialChar,
+    ],
+  ])('%s - "%s"', async (_, password, expectedErrorMessage) => {
     render(<LoginForm />);
 
     fireEvent.change(screen.getByPlaceholderText(Placeholders.Password), { target: { value: password } });
 
-    expect(await screen.findByText(formatMessage(ValidationMessages.PasswordPattern))).toBeInTheDocument();
+    expect(await screen.findByText(expectedErrorMessage)).toBeInTheDocument();
   });
 });

--- a/components/home/home.tsx
+++ b/components/home/home.tsx
@@ -1,15 +1,12 @@
 import { Col, List, Row } from 'antd';
-import { useContext } from 'react';
-import { navigationMainPage, navigationMainPageForAuthorizedUser } from '@/utils/route-links';
-import { AuthContext } from '../../context/authorization-context';
+import { navigationMainPage } from '@/utils/route-links';
 
 const Home = (): JSX.Element => {
-  const { isLoggedIn } = useContext(AuthContext);
   return (
     <>
       <List
         bordered
-        dataSource={isLoggedIn ? navigationMainPageForAuthorizedUser : navigationMainPage}
+        dataSource={navigationMainPage}
         renderItem={(item) => (
           <List.Item>
             <Row justify="start" gutter={8}>

--- a/components/login-form/login-form.tsx
+++ b/components/login-form/login-form.tsx
@@ -4,8 +4,8 @@ import { LockOutlined, MailOutlined, EyeInvisibleOutlined, EyeTwoTone } from '@a
 import { useContext } from 'react';
 import loginUser from '../../pages/api/login-user';
 import { AuthContext } from '../../context/authorization-context';
-import validatePasswordRegExp from '../../utils/input-validation';
-import { FieldType, Placeholders, ValidationMessages } from './types.login';
+import { FieldType, Placeholders } from './types.login';
+import { getEmailRules, getPasswordRules } from '../registration-form/helpers/validation-rules';
 
 const { Link } = Typography;
 
@@ -67,28 +67,11 @@ const LoginForm: React.FC = () => {
           >
             <Space direction="vertical" size="middle" style={{ display: 'flex' }}>
               <div>
-                <Form.Item
-                  label="Email"
-                  name="email"
-                  rules={[
-                    { required: true, message: ValidationMessages.EmailRequired },
-                    { type: 'email', message: ValidationMessages.EmailInvalid },
-                  ]}
-                >
+                <Form.Item label="Email" name="email" rules={getEmailRules()}>
                   <Input prefix={<MailOutlined style={iconStyle} />} placeholder={Placeholders.Email} />
                 </Form.Item>
 
-                <Form.Item
-                  label="Password"
-                  name="password"
-                  rules={[
-                    { required: true, message: ValidationMessages.PasswordRequired },
-                    {
-                      pattern: validatePasswordRegExp,
-                      message: ValidationMessages.PasswordPattern,
-                    },
-                  ]}
-                >
+                <Form.Item label="Password" name="password" rules={getPasswordRules()}>
                   <Input.Password
                     prefix={<LockOutlined style={iconStyle} />}
                     placeholder={Placeholders.Password}

--- a/components/login-form/types.login.tsx
+++ b/components/login-form/types.login.tsx
@@ -5,14 +5,29 @@ export type FieldType = {
 
 export enum Placeholders {
   Email = 'your.email@gmail.com',
-  Password = 'Password',
+  Password = 'securePassword1!',
 }
 
-export enum ValidationMessages {
-  EmailRequired = 'Please enter your email',
-  EmailInvalid = 'The email is not valid',
-  PasswordRequired = 'Please enter your password',
-  PasswordPattern = `Your password must contain at least 8 characters, at least one uppercase and lowercase letter, 
-                    digit, and special character (such as !, @, #, $, etc.) 
-                    and must not start or end with a whitespace character.`,
+// export enum ValidationMessages {
+//   EmailRequired = 'Please enter your email',
+//   EmailInvalid = 'The email is not valid',
+//   PasswordRequired = 'Please enter your password',
+//   PasswordPattern = `Your password must contain at least 8 characters, at least one uppercase and lowercase letter,
+//                     digit, and special character (such as !, @, #, $, etc.)
+//                     and must not start or end with a whitespace character.`,
+// }
+
+export enum EmailValidationMessages {
+  required = 'Please enter your e-mail',
+  invalid = 'Your e-mail is incorrectly formatted',
+}
+
+export enum PasswordValidationMessages {
+  required = 'Please enter your password',
+  hasWhitespaces = 'Password must not contain whitespaces',
+  isShort = 'Password must have at least 8 characters',
+  hasNoLowercase = 'Password must have at least 1 lowercase character',
+  hasNoUppercase = 'Password must have at least 1 uppercase character',
+  hasNoNumber = 'Password must have at least 1 number character',
+  hasNoSpecialChar = 'Password must have at least 1 special character',
 }

--- a/components/registration-form/fields/password-field.tsx
+++ b/components/registration-form/fields/password-field.tsx
@@ -14,7 +14,7 @@ interface PasswordFieldProps {
 const PasswordField: React.FC<PasswordFieldProps> = ({
   label = 'Password',
   name,
-  placeholder = 'securePassword1',
+  placeholder = 'securePassword1!',
   rules,
   iconStyle,
   hasFeedback = false,

--- a/components/registration-form/fields/switch-field.tsx
+++ b/components/registration-form/fields/switch-field.tsx
@@ -1,4 +1,4 @@
-import { Form, Switch, Row, Col } from 'antd';
+import { Form, Switch } from 'antd';
 
 interface SwitchFieldProps {
   name: string;
@@ -7,14 +7,12 @@ interface SwitchFieldProps {
 }
 
 const SwitchField: React.FC<SwitchFieldProps> = ({ name, label }) => (
-  <Row align="middle">
-    <Col>
-      <Form.Item name={name} valuePropName="checked">
-        <Switch defaultChecked />
-      </Form.Item>
-    </Col>
-    <Col>{label && <span style={{ marginLeft: '8px' }}>{label}</span>}</Col>
-  </Row>
+  <div style={{ display: 'inline-flex', alignItems: 'center' }}>
+    <Form.Item name={name} valuePropName="checked" style={{ marginBlock: 'auto' }}>
+      <Switch defaultChecked />
+    </Form.Item>
+    <span style={{ marginLeft: '8px' }}>{label}</span>
+  </div>
 );
 
 export default SwitchField;

--- a/components/registration-form/helpers/field-definitions.ts
+++ b/components/registration-form/helpers/field-definitions.ts
@@ -21,14 +21,19 @@ const fieldDefinitions = {
     name: 'gender',
     placeholder: 'Select Gender',
   },
+  city: {
+    label: 'City',
+    name: `${AddressFieldsName.CITY}`,
+    placeholder: 'New York',
+  },
   street: {
     label: 'Street',
-    name: `${AddressFieldsName.STREET_NAME}`,
+    name: `${AddressFieldsName.STREET}`,
     placeholder: 'Park Avenue',
   },
-  streetNumber: {
-    label: 'Street Number',
-    name: `${AddressFieldsName.STREET_NUMBER}`,
+  building: {
+    label: 'Building',
+    name: `${AddressFieldsName.BUILDING}`,
     placeholder: '34',
   },
   apartment: {

--- a/components/registration-form/helpers/registration.types.ts
+++ b/components/registration-form/helpers/registration.types.ts
@@ -1,30 +1,33 @@
 export enum AddressFieldsName {
-  COUNTRY = `country`,
-  STREET_NAME = `streetName`,
-  STREET_NUMBER = `streetNumber`,
-  APARTMENT = `apartment`,
-  POSTAL_CODE = `postalCode`,
-  SET_AS_DEFAULT = `setAsDefault`,
-  USE_AS_BILLING_ADDRESS = `useAsBillingAddress`,
+  COUNTRY = 'country',
+  CITY = 'city',
+  STREET = 'street',
+  BUILDING = 'building',
+  APARTMENT = 'apartment',
+  POSTAL_CODE = 'postalCode',
+  SET_AS_DEFAULT = 'setAsDefault',
+  USE_AS_BILLING_ADDRESS = 'useAsBillingAddress',
 }
 
 export enum AddressSuffix {
-  SHIPPING = `_shipping`,
-  BILLING = `_billing`,
+  SHIPPING = '_shipping',
+  BILLING = '_billing',
 }
 
 export enum ShippingFieldsName {
   COUNTRY = `${AddressFieldsName.COUNTRY}${AddressSuffix.SHIPPING}`,
-  STREET_NAME = `${AddressFieldsName.STREET_NAME}${AddressSuffix.SHIPPING}`,
-  STREET_NUMBER = `${AddressFieldsName.STREET_NUMBER}${AddressSuffix.SHIPPING}`,
+  CITY = `${AddressFieldsName.CITY}${AddressSuffix.SHIPPING}`,
+  STREET = `${AddressFieldsName.STREET}${AddressSuffix.SHIPPING}`,
+  BUILDING = `${AddressFieldsName.BUILDING}${AddressSuffix.SHIPPING}`,
   APARTMENT = `${AddressFieldsName.APARTMENT}${AddressSuffix.SHIPPING}`,
   POSTAL_CODE = `${AddressFieldsName.POSTAL_CODE}${AddressSuffix.SHIPPING}`,
 }
 
 export enum BillingFieldsName {
   COUNTRY = `${AddressFieldsName.COUNTRY}${AddressSuffix.BILLING}`,
-  STREET_NAME = `${AddressFieldsName.STREET_NAME}${AddressSuffix.BILLING}`,
-  STREET_NUMBER = `${AddressFieldsName.STREET_NUMBER}${AddressSuffix.BILLING}`,
+  CITY = `${AddressFieldsName.CITY}${AddressSuffix.BILLING}`,
+  STREET = `${AddressFieldsName.STREET}${AddressSuffix.BILLING}`,
+  BUILDING = `${AddressFieldsName.BUILDING}${AddressSuffix.BILLING}`,
   APARTMENT = `${AddressFieldsName.APARTMENT}${AddressSuffix.BILLING}`,
   POSTAL_CODE = `${AddressFieldsName.POSTAL_CODE}${AddressSuffix.BILLING}`,
 }
@@ -36,13 +39,14 @@ export type FormData = {
   lastName: string;
   dateOfBirth: moment.Moment;
   [ShippingFieldsName.COUNTRY]: string;
-  [ShippingFieldsName.STREET_NAME]: string;
-  [ShippingFieldsName.STREET_NUMBER]: string;
+  [ShippingFieldsName.CITY]: string;
+  [ShippingFieldsName.STREET]: string;
+  [ShippingFieldsName.BUILDING]: string;
   [ShippingFieldsName.APARTMENT]: string;
   [ShippingFieldsName.POSTAL_CODE]: string;
   [BillingFieldsName.COUNTRY]: string;
-  [BillingFieldsName.STREET_NAME]: string;
-  [BillingFieldsName.STREET_NUMBER]: string;
+  [BillingFieldsName.STREET]: string;
+  [BillingFieldsName.BUILDING]: string;
   [BillingFieldsName.APARTMENT]: string;
   [BillingFieldsName.POSTAL_CODE]: string;
   gender: string;

--- a/components/registration-form/helpers/validation-rules.ts
+++ b/components/registration-form/helpers/validation-rules.ts
@@ -3,14 +3,14 @@ import { FormInstance } from 'antd/lib/form';
 import postalCodes from 'postal-codes-js';
 import { getCode } from 'country-list';
 
-import hasOnlyLetters from '@/utils/inputs-validation/checkOnlyLetters';
-import isCertainAge from '@/utils/inputs-validation/checkAge';
-import checkLength from '@/utils/inputs-validation/checkLength';
-import hasMinimumLowercase from '@/utils/inputs-validation/checkLowerCaseCount';
-import hasMinimumUppercase from '@/utils/inputs-validation/checkUppercaseCount';
-import hasMinimumNumbers from '@/utils/inputs-validation/checkNumbersCount';
-import hasNoSpaces from '@/utils/inputs-validation/checkNoSpaces';
-import hasSpecialCharacters from '@/utils/inputs-validation/checkSpecialChars';
+import hasSpecialCharacters from '../../../utils/inputs-validation/checkSpecialChars';
+import hasNoSpaces from '../../../utils/inputs-validation/checkNoSpaces';
+import hasMinimumNumbers from '../../../utils/inputs-validation/checkNumbersCount';
+import hasMinimumUppercase from '../../../utils/inputs-validation/checkUppercaseCount';
+import hasMinimumLowercase from '../../../utils/inputs-validation/checkLowerCaseCount';
+import checkLength from '../../../utils/inputs-validation/checkLength';
+import isCertainAge from '../../../utils/inputs-validation/checkAge';
+import hasOnlyLetters from '../../../utils/inputs-validation/checkOnlyLetters';
 
 const getNameRules = (): Rule[] => [
   {
@@ -20,7 +20,7 @@ const getNameRules = (): Rule[] => [
   {
     validator: (_, value: string) => {
       if (!hasOnlyLetters(value)) {
-        return Promise.reject(new Error('Name can only contain letters'));
+        return Promise.reject(new Error('Name can only contain latin letters'));
       }
       return Promise.resolve();
     },
@@ -35,7 +35,7 @@ const getSurnameRules = (): Rule[] => [
   {
     validator: (_, value: string) => {
       if (!hasOnlyLetters(value)) {
-        return Promise.reject(new Error('Surname can only contain letters'));
+        return Promise.reject(new Error('Surname can only contain latin letters'));
       }
       return Promise.resolve();
     },
@@ -46,7 +46,7 @@ const getBirthDateRules = (): Rule[] => [
   {
     validator: (_, value: string) => {
       if (!value) {
-        return Promise.reject(new Error('Please input your date of birth'));
+        return Promise.reject(new Error('Please enter your date of birth'));
       }
       if (!isCertainAge(value, 13)) {
         return Promise.reject(new Error('You should be at least 13 years old to register'));
@@ -74,8 +74,23 @@ const getCountryRules = (): Rule[] => [
   },
 ];
 
+const getCityRules = (): Rule[] => [
+  {
+    required: true,
+    message: 'City must have at least one character',
+  },
+  {
+    validator: (_, value: string) => {
+      if (!hasOnlyLetters(value)) {
+        return Promise.reject(new Error('City can only contain latin letters'));
+      }
+      return Promise.resolve();
+    },
+  },
+];
+
 const getEmailRules = (): Rule[] => [
-  { required: true, message: 'Please input your e-mail' },
+  { required: true, message: 'Please enter your e-mail' },
   { type: 'email', message: 'Your e-mail is incorrectly formatted' },
 ];
 
@@ -83,7 +98,7 @@ const getPasswordRules = (): Rule[] => [
   {
     validator: (_, value: string) => {
       if (!value) {
-        return Promise.reject(new Error('Please input your password'));
+        return Promise.reject(new Error('Please enter your password'));
       }
       if (!hasNoSpaces(value)) {
         return Promise.reject(new Error('Password must not contain whitespaces'));
@@ -115,7 +130,7 @@ const getPostalCodeRules = (form: FormInstance, fieldName: string): Rule[] => [
       const countryCode = countryName ? getCode(countryName) : null;
 
       if (!value) {
-        return Promise.reject(new Error(`Please input postal code`));
+        return Promise.reject(new Error(`Please enter postal code`));
       }
       if (!countryCode) {
         return Promise.reject(new Error(`Please choose country`));
@@ -137,6 +152,7 @@ export {
   getBirthDateRules,
   getStreetRules,
   getCountryRules,
+  getCityRules,
   getEmailRules,
   getPasswordRules,
   getPostalCodeRules,

--- a/components/registration-form/sections/address-section.tsx
+++ b/components/registration-form/sections/address-section.tsx
@@ -7,7 +7,7 @@ import SelectField from '../fields/select-field';
 import SwitchField from '../fields/switch-field';
 import DividerText from '../fields/divider-field';
 
-import { getStreetRules, getCountryRules, getPostalCodeRules } from '../helpers/validation-rules';
+import { getStreetRules, getCountryRules, getPostalCodeRules, getCityRules } from '../helpers/validation-rules';
 import fieldDefinitions from '../helpers/field-definitions';
 import { AddressFieldsName, ShippingFieldsName } from '../helpers/registration.types';
 
@@ -28,8 +28,9 @@ const AddressSection: React.FC<AddressSectionProps> = ({
   showCheckbox = false,
   onUseBillingAddressChange,
 }) => {
-  const streetFieldName = `${AddressFieldsName.STREET_NAME}${nameSuffix}`;
-  const houseFieldName = `${AddressFieldsName.STREET_NUMBER}${nameSuffix}`;
+  const streetFieldName = `${AddressFieldsName.STREET}${nameSuffix}`;
+  const cityFieldName = `${AddressFieldsName.CITY}${nameSuffix}`;
+  const buildingFieldName = `${AddressFieldsName.BUILDING}${nameSuffix}`;
   const flatFieldName = `${AddressFieldsName.APARTMENT}${nameSuffix}`;
   const countryFieldName = `${AddressFieldsName.COUNTRY}${nameSuffix}`;
   const postalCodeFieldName = `${AddressFieldsName.POSTAL_CODE}${nameSuffix}`;
@@ -39,17 +40,19 @@ const AddressSection: React.FC<AddressSectionProps> = ({
   const handleUseBillingAddressChange = (e: CheckboxChangeEvent) => {
     if (onUseBillingAddressChange) {
       const shippingAddressValues = form.getFieldsValue([
-        ShippingFieldsName.STREET_NAME,
-        ShippingFieldsName.STREET_NUMBER,
+        ShippingFieldsName.STREET,
+        ShippingFieldsName.BUILDING,
         ShippingFieldsName.APARTMENT,
         ShippingFieldsName.COUNTRY,
+        ShippingFieldsName.CITY,
         ShippingFieldsName.POSTAL_CODE,
       ]);
 
       form.setFieldsValue({
-        street_billing: shippingAddressValues[ShippingFieldsName.STREET_NAME],
-        house_billing: shippingAddressValues[ShippingFieldsName.STREET_NUMBER],
-        flat_billing: shippingAddressValues[ShippingFieldsName.APARTMENT],
+        city_billing: shippingAddressValues[ShippingFieldsName.CITY],
+        street_billing: shippingAddressValues[ShippingFieldsName.STREET],
+        building_billing: shippingAddressValues[ShippingFieldsName.BUILDING],
+        apartment_billing: shippingAddressValues[ShippingFieldsName.APARTMENT],
         country_billing: shippingAddressValues[ShippingFieldsName.COUNTRY],
         postalCode_billing: shippingAddressValues[ShippingFieldsName.POSTAL_CODE],
       });
@@ -62,16 +65,7 @@ const AddressSection: React.FC<AddressSectionProps> = ({
   return (
     <>
       <DividerText text={title} />
-
-      <InputField {...fieldDefinitions.street} name={streetFieldName} required={true} rules={getStreetRules()} />
-
       <Row gutter={16}>
-        <Col xs={24} sm={24} md={12} lg={12} xl={12}>
-          <InputField {...fieldDefinitions.streetNumber} name={houseFieldName} rules={[]}></InputField>
-        </Col>
-        <Col xs={24} sm={24} md={12} lg={12} xl={12}>
-          <InputField {...fieldDefinitions.apartment} name={flatFieldName} rules={[]}></InputField>
-        </Col>
         <Col xs={24} sm={24} md={12} lg={12} xl={12}>
           <SelectField
             {...fieldDefinitions.country}
@@ -91,13 +85,22 @@ const AddressSection: React.FC<AddressSectionProps> = ({
             required={true}
           ></InputField>
         </Col>
-      </Row>
-
-      <Row>
         <Col xs={24} sm={24} md={12} lg={12} xl={12}>
-          <Form.Item valuePropName="checked">
-            <SwitchField name={setAsDefault} {...fieldDefinitions.defaultAddress}></SwitchField>
-          </Form.Item>
+          <InputField {...fieldDefinitions.city} name={cityFieldName} required={true} rules={getCityRules()} />
+        </Col>
+        <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+          <InputField {...fieldDefinitions.street} name={streetFieldName} required={true} rules={getStreetRules()} />
+        </Col>
+        <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+          <InputField {...fieldDefinitions.building} name={buildingFieldName} rules={[]}></InputField>
+        </Col>
+        <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+          <InputField {...fieldDefinitions.apartment} name={flatFieldName} rules={[]}></InputField>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+          <SwitchField name={setAsDefault} {...fieldDefinitions.defaultAddress}></SwitchField>
         </Col>
         <Col xs={24} sm={24} md={12} lg={12} xl={12}>
           {showCheckbox && (

--- a/components/registration-form/sections/personal-section.tsx
+++ b/components/registration-form/sections/personal-section.tsx
@@ -13,8 +13,8 @@ const PersonalSection: React.FC = () => {
     <>
       <DividerText text="Personal" />
 
-      <InputField {...fieldDefinitions.name} rules={getNameRules()} />
-      <InputField {...fieldDefinitions.surname} rules={getSurnameRules()} />
+      <InputField {...fieldDefinitions.name} required={true} rules={getNameRules()} />
+      <InputField {...fieldDefinitions.surname} required={true} rules={getSurnameRules()} />
 
       <Row gutter={16}>
         <Col xs={24} sm={24} md={12} lg={12} xl={12}>

--- a/utils/input-validation.ts
+++ b/utils/input-validation.ts
@@ -1,3 +1,0 @@
-const validatePasswordRegExp = /(^(?![\s]))(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*\W)(.{7,})(.*!?(\S+)$)/;
-
-export default validatePasswordRegExp;

--- a/utils/route-links.tsx
+++ b/utils/route-links.tsx
@@ -1,12 +1,4 @@
-import {
-  HomeOutlined,
-  LoginOutlined,
-  UserOutlined,
-  ShoppingOutlined,
-  ShoppingCartOutlined,
-  LogoutOutlined,
-} from '@ant-design/icons';
-import { Button } from 'antd';
+import { HomeOutlined, LoginOutlined, UserOutlined, ShoppingOutlined, ShoppingCartOutlined } from '@ant-design/icons';
 import Link from 'next/link';
 
 export enum Paths {


### PR DESCRIPTION
#### PR Type

What kind of change does this PR introduce?

- [ ] New feature
- [ ] Breaking change
- [x] Bug fix
- [ ] Docs
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Tests
- [ ] Other

#### Related Tasks

- **EA-113**: Add City field to registration form
- **EA-110**: Fix the possibility to use whitespace in the middle of the password
- **EA-114**: Fix text positioning in switch element
- **EA-115**: Fix links list on the main page
- **EA-117**: Fix postal code validation issues (hyphen)

#### Changes made

- [x] Added 'City' field to the registration form
- [x] Added validation for 'City' field
- [x] Unified the validation of repeating fields in 'Register' and 'Login' forms for consistency (previously different regex and error messages were used)
- [x] Adapted 'Login' tests for new error messages
- [x] Placed errors text in separate enums (to be updated)
- [x] Fixed switch positioning in 'Registration' form
- [x] Removed the check of user to display the appropriate links on the main page
- [x] Fixed issue with postal code validation 

#### Additional info

While working on **EA-115**, I was not sure whether to remove redundant code from files like `authorization-context.tsx` or not, so I left it untouched, @alikri when you have time, please revise that file and decide on which code to leave and which to delete 🙏 
